### PR TITLE
[WEEK12] 김경연 - Memory Management

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -1,5 +1,6 @@
 #ifndef VM_VM_H
 #define VM_VM_H
+#include "lib/kernel/hash.h"
 #include "threads/palloc.h"
 #include <stdbool.h>
 
@@ -46,7 +47,8 @@ struct page {
   struct frame *frame; /* Back reference for frame */
 
   /* Your implementation */
-  bool writable; // 이 페이지가 쓰기 가능한지 여부
+  bool writable;              // 이 페이지가 쓰기 가능한지 여부
+  struct hash_elem hash_elem; // 해시 테이블용
 
   /* Per-type data are binded into the union.
    * Each function automatically detects the current union */
@@ -88,7 +90,9 @@ struct page_operations {
 /* Representation of current process's memory space.
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
-struct supplemental_page_table {};
+struct supplemental_page_table {
+  struct hash hash_table;
+};
 
 #include "threads/thread.h"
 void supplemental_page_table_init(struct supplemental_page_table *spt);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -1,32 +1,32 @@
 #ifndef VM_VM_H
 #define VM_VM_H
-#include <stdbool.h>
 #include "threads/palloc.h"
+#include <stdbool.h>
 
 enum vm_type {
-	/* page not initialized */
-	VM_UNINIT = 0,
-	/* page not related to the file, aka anonymous page */
-	VM_ANON = 1,
-	/* page that realated to the file */
-	VM_FILE = 2,
-	/* page that hold the page cache, for project 4 */
-	VM_PAGE_CACHE = 3,
+  /* page not initialized */
+  VM_UNINIT = 0,
+  /* page not related to the file, aka anonymous page */
+  VM_ANON = 1,
+  /* page that realated to the file */
+  VM_FILE = 2,
+  /* page that hold the page cache, for project 4 */
+  VM_PAGE_CACHE = 3,
 
-	/* Bit flags to store state */
+  /* Bit flags to store state */
 
-	/* Auxillary bit flag marker for store information. You can add more
-	 * markers, until the value is fit in the int. */
-	VM_MARKER_0 = (1 << 3),
-	VM_MARKER_1 = (1 << 4),
+  /* Auxillary bit flag marker for store information. You can add more
+   * markers, until the value is fit in the int. */
+  VM_MARKER_0 = (1 << 3),
+  VM_MARKER_1 = (1 << 4),
 
-	/* DO NOT EXCEED THIS VALUE. */
-	VM_MARKER_END = (1 << 31),
+  /* DO NOT EXCEED THIS VALUE. */
+  VM_MARKER_END = (1 << 31),
 };
 
-#include "vm/uninit.h"
 #include "vm/anon.h"
 #include "vm/file.h"
+#include "vm/uninit.h"
 #ifdef EFILESYS
 #include "filesys/page_cache.h"
 #endif
@@ -41,28 +41,31 @@ struct thread;
  * uninit_page, file_page, anon_page, and page cache (project4).
  * DO NOT REMOVE/MODIFY PREDEFINED MEMBER OF THIS STRUCTURE. */
 struct page {
-	const struct page_operations *operations;
-	void *va;              /* Address in terms of user space */
-	struct frame *frame;   /* Back reference for frame */
+  const struct page_operations *operations;
+  void *va;            /* Address in terms of user space */
+  struct frame *frame; /* Back reference for frame */
 
-	/* Your implementation */
+  /* Your implementation */
+  bool writable; // 이 페이지가 쓰기 가능한지 여부
 
-	/* Per-type data are binded into the union.
-	 * Each function automatically detects the current union */
-	union {
-		struct uninit_page uninit;
-		struct anon_page anon;
-		struct file_page file;
+  /* Per-type data are binded into the union.
+   * Each function automatically detects the current union */
+  union {
+    struct uninit_page uninit;
+    struct anon_page anon;
+    struct file_page file;
 #ifdef EFILESYS
-		struct page_cache page_cache;
+    struct page_cache page_cache;
 #endif
-	};
+  };
 };
 
 /* The representation of "frame" */
+/* Frame Table에서 사용하는 구조체 */
 struct frame {
-	void *kva;
-	struct page *page;
+  void *kva;             // 커널 가상주소 (palloc으로 얻은 물리 메모리)
+  struct page *page;     // 이 frame을 사용하는 페이지 (역참조)
+  struct list_elem elem; // frame table에서 사용할 list 요소
 };
 
 /* The function table for page operations.
@@ -70,43 +73,43 @@ struct frame {
  * Put the table of "method" into the struct's member, and
  * call it whenever you needed. */
 struct page_operations {
-	bool (*swap_in) (struct page *, void *);
-	bool (*swap_out) (struct page *);
-	void (*destroy) (struct page *);
-	enum vm_type type;
+  bool (*swap_in)(struct page *, void *);
+  bool (*swap_out)(struct page *);
+  void (*destroy)(struct page *);
+  enum vm_type type;
 };
 
-#define swap_in(page, v) (page)->operations->swap_in ((page), v)
-#define swap_out(page) (page)->operations->swap_out (page)
-#define destroy(page) \
-	if ((page)->operations->destroy) (page)->operations->destroy (page)
+#define swap_in(page, v) (page)->operations->swap_in((page), v)
+#define swap_out(page) (page)->operations->swap_out(page)
+#define destroy(page)                                                          \
+  if ((page)->operations->destroy)                                             \
+  (page)->operations->destroy(page)
 
 /* Representation of current process's memory space.
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
-struct supplemental_page_table {
-};
+struct supplemental_page_table {};
 
 #include "threads/thread.h"
-void supplemental_page_table_init (struct supplemental_page_table *spt);
-bool supplemental_page_table_copy (struct supplemental_page_table *dst,
-		struct supplemental_page_table *src);
-void supplemental_page_table_kill (struct supplemental_page_table *spt);
-struct page *spt_find_page (struct supplemental_page_table *spt,
-		void *va);
-bool spt_insert_page (struct supplemental_page_table *spt, struct page *page);
-void spt_remove_page (struct supplemental_page_table *spt, struct page *page);
+void supplemental_page_table_init(struct supplemental_page_table *spt);
+bool supplemental_page_table_copy(struct supplemental_page_table *dst,
+                                  struct supplemental_page_table *src);
+void supplemental_page_table_kill(struct supplemental_page_table *spt);
+struct page *spt_find_page(struct supplemental_page_table *spt, void *va);
+bool spt_insert_page(struct supplemental_page_table *spt, struct page *page);
+void spt_remove_page(struct supplemental_page_table *spt, struct page *page);
 
-void vm_init (void);
-bool vm_try_handle_fault (struct intr_frame *f, void *addr, bool user,
-		bool write, bool not_present);
+void vm_init(void);
+bool vm_try_handle_fault(struct intr_frame *f, void *addr, bool user,
+                         bool write, bool not_present);
 
-#define vm_alloc_page(type, upage, writable) \
-	vm_alloc_page_with_initializer ((type), (upage), (writable), NULL, NULL)
-bool vm_alloc_page_with_initializer (enum vm_type type, void *upage,
-		bool writable, vm_initializer *init, void *aux);
-void vm_dealloc_page (struct page *page);
-bool vm_claim_page (void *va);
-enum vm_type page_get_type (struct page *page);
+#define vm_alloc_page(type, upage, writable)                                   \
+  vm_alloc_page_with_initializer((type), (upage), (writable), NULL, NULL)
+bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,
+                                    bool writable, vm_initializer *init,
+                                    void *aux);
+void vm_dealloc_page(struct page *page);
+bool vm_claim_page(void *va);
+enum vm_type page_get_type(struct page *page);
 
-#endif  /* VM_VM_H */
+#endif /* VM_VM_H */

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -1,190 +1,211 @@
 /* vm.c: Generic interface for virtual memory objects. */
+/* vm.c: 가상 메모리 객체를 위한 일반 인터페이스. */
 
-#include "threads/malloc.h"
 #include "vm/vm.h"
+#include "threads/malloc.h"
 #include "vm/inspect.h"
 
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
-void
-vm_init (void) {
-	vm_anon_init ();
-	vm_file_init ();
-#ifdef EFILESYS  /* For project 4 */
-	pagecache_init ();
+// 각 하위 시스템의 초기화 코드를 호출하여 가상 메모리 하위 시스템을
+// 초기화합니다.
+void vm_init(void) {
+  vm_anon_init();
+  vm_file_init();
+#ifdef EFILESYS /* For project 4 */
+  pagecache_init();
 #endif
-	register_inspect_intr ();
-	/* DO NOT MODIFY UPPER LINES. */
-	/* TODO: Your code goes here. */
+  register_inspect_intr();
+  /* DO NOT MODIFY UPPER LINES. */
+  // ※ 위의 라인은 수정하지마세요. ※
+  /* TODO: Your code goes here. */
 }
 
 /* Get the type of the page. This function is useful if you want to know the
  * type of the page after it will be initialized.
  * This function is fully implemented now. */
-enum vm_type
-page_get_type (struct page *page) {
-	int ty = VM_TYPE (page->operations->type);
-	switch (ty) {
-		case VM_UNINIT:
-			return VM_TYPE (page->uninit.type);
-		default:
-			return ty;
-	}
+// 페이지 유형을 가져옵니다. 이 함수는 페이지가 초기화된 후 페이지의 유형을 알고
+// 싶을 때 유용합니다. 이 함수는 현재 완전히 구현되었습니다.
+enum vm_type page_get_type(struct page *page) {
+  int ty = VM_TYPE(page->operations->type);
+  switch (ty) {
+  case VM_UNINIT:
+    return VM_TYPE(page->uninit.type);
+  default:
+    return ty;
+  }
 }
 
 /* Helpers */
-static struct frame *vm_get_victim (void);
-static bool vm_do_claim_page (struct page *page);
-static struct frame *vm_evict_frame (void);
+static struct frame *vm_get_victim(void);
+static bool vm_do_claim_page(struct page *page);
+static struct frame *vm_evict_frame(void);
 
 /* Create the pending page object with initializer. If you want to create a
  * page, do not create it directly and make it through this function or
  * `vm_alloc_page`. */
-bool
-vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
-		vm_initializer *init, void *aux) {
+// 초기화 함수를 사용하여 보류 중인 페이지 객체를 생성합니다.
+// 페이지를 생성하려면 직접 생성하지 말고 이 함수나 `vm_alloc_page`를 통해
+// 생성하세요.
+bool vm_alloc_page_with_initializer(enum vm_type type, void *upage,
+                                    bool writable, vm_initializer *init,
+                                    void *aux) {
 
-	ASSERT (VM_TYPE(type) != VM_UNINIT)
+  ASSERT(VM_TYPE(type) != VM_UNINIT)
 
-	struct supplemental_page_table *spt = &thread_current ()->spt;
+  struct supplemental_page_table *spt = &thread_current()->spt;
 
-	/* Check wheter the upage is already occupied or not. */
-	if (spt_find_page (spt, upage) == NULL) {
-		/* TODO: Create the page, fetch the initialier according to the VM type,
-		 * TODO: and then create "uninit" page struct by calling uninit_new. You
-		 * TODO: should modify the field after calling the uninit_new. */
+  /* Check wheter the upage is already occupied or not. */
+  // 이미지가 이미 점유되어 있는지 확인하세요.
+  if (spt_find_page(spt, upage) == NULL) {
+    /* TODO: Create the page, fetch the initialier according to the VM type,
+     * TODO: and then create "uninit" page struct by calling uninit_new. You
+     * TODO: should modify the field after calling the uninit_new. */
+    // 해야될 것: 페이지를 생성하고, VM 유형에 따라 초기화 파일을 가져온 후,
+    // uninit_new를 호출하여 "uninit" 페이지 구조체를 생성합니다. 해야될 것:
+    // uninit_new를 호출한 후 필드를 수정해야 합니다.
 
-		/* TODO: Insert the page into the spt. */
-	}
+    /* TODO: Insert the page into the spt. */
+    // 해당 페이지를 spt에 삽입합니다.
+  }
 err:
-	return false;
+  return false;
 }
 
 /* Find VA from spt and return page. On error, return NULL. */
-struct page *
-spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
-	struct page *page = NULL;
-	/* TODO: Fill this function. */
+// spt에서 VA를 찾아 페이지를 반환합니다. 오류가 발생하면 NULL을 반환합니다.
+struct page *spt_find_page(struct supplemental_page_table *spt UNUSED,
+                           void *va UNUSED) {
+  struct page *page = NULL;
+  /* TODO: Fill this function. */
 
-	return page;
+  return page;
 }
 
 /* Insert PAGE into spt with validation. */
-bool
-spt_insert_page (struct supplemental_page_table *spt UNUSED,
-		struct page *page UNUSED) {
-	int succ = false;
-	/* TODO: Fill this function. */
+// 검증을 통해 spt에 PAGE를 삽입합니다.
+bool spt_insert_page(struct supplemental_page_table *spt UNUSED,
+                     struct page *page UNUSED) {
+  int succ = false;
+  /* TODO: Fill this function. */
 
-	return succ;
+  return succ;
 }
 
-void
-spt_remove_page (struct supplemental_page_table *spt, struct page *page) {
-	vm_dealloc_page (page);
-	return true;
+void spt_remove_page(struct supplemental_page_table *spt, struct page *page) {
+  vm_dealloc_page(page);
+  return true;
 }
 
 /* Get the struct frame, that will be evicted. */
-static struct frame *
-vm_get_victim (void) {
-	struct frame *victim = NULL;
-	 /* TODO: The policy for eviction is up to you. */
+// 내보낼 구조체 프레임을 가져옵니다.
+static struct frame *vm_get_victim(void) {
+  struct frame *victim = NULL;
+  /* TODO: The policy for eviction is up to you. 내보내는 규칙은 본인이
+   * 정하세요.*/
 
-	return victim;
+  return victim;
 }
 
 /* Evict one page and return the corresponding frame.
  * Return NULL on error.*/
-static struct frame *
-vm_evict_frame (void) {
-	struct frame *victim UNUSED = vm_get_victim ();
-	/* TODO: swap out the victim and return the evicted frame. */
+// 한 페이지를 제거하고 해당 프레임을 반환합니다.
+// 오류 발생 시 NULL을 반환합니다.
+static struct frame *vm_evict_frame(void) {
+  struct frame *victim UNUSED = vm_get_victim();
+  /* TODO: swap out the victim and return the evicted frame. */
 
-	return NULL;
+  return NULL;
 }
 
 /* palloc() and get frame. If there is no available page, evict the page
  * and return it. This always return valid address. That is, if the user pool
  * memory is full, this function evicts the frame to get the available memory
  * space.*/
-static struct frame *
-vm_get_frame (void) {
-	struct frame *frame = NULL;
-	/* TODO: Fill this function. */
+// palloc() 함수는 프레임을 가져옵니다. 사용 가능한 페이지가 없으면 해당
+// 페이지를 제거하고 반환합니다. 이 함수는 항상 유효한 주소를 반환합니다. 즉,
+// 사용자 풀 메모리가 가득 차면 이 함수는 프레임을 제거하여 사용 가능한 메모리
+// 공간을 가져옵니다.
+static struct frame *vm_get_frame(void) {
+  struct frame *frame = NULL;
+  /* TODO: Fill this function. */
 
-	ASSERT (frame != NULL);
-	ASSERT (frame->page == NULL);
-	return frame;
+  ASSERT(frame != NULL);
+  ASSERT(frame->page == NULL);
+  return frame;
 }
 
 /* Growing the stack. */
-static void
-vm_stack_growth (void *addr UNUSED) {
-}
+// 스택을 키웁니다.
+static void vm_stack_growth(void *addr UNUSED) {}
 
 /* Handle the fault on write_protected page */
-static bool
-vm_handle_wp (struct page *page UNUSED) {
-}
+// write_protected 페이지에서 오류를 처리합니다.
+static bool vm_handle_wp(struct page *page UNUSED) {}
 
 /* Return true on success */
-bool
-vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
-		bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
-	struct supplemental_page_table *spt UNUSED = &thread_current ()->spt;
-	struct page *page = NULL;
-	/* TODO: Validate the fault */
-	/* TODO: Your code goes here */
+// 성공 시 true를 반환합니다.
+bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
+                         bool user UNUSED, bool write UNUSED,
+                         bool not_present UNUSED) {
+  struct supplemental_page_table *spt UNUSED = &thread_current()->spt;
+  struct page *page = NULL;
+  /* TODO: Validate the fault */
+  // 오류를 검증하세요
+  /* TODO: Your code goes here */
+  // 코드를 여기에 적으세요
 
-	return vm_do_claim_page (page);
+  return vm_do_claim_page(page);
 }
 
 /* Free the page.
  * DO NOT MODIFY THIS FUNCTION. */
-void
-vm_dealloc_page (struct page *page) {
-	destroy (page);
-	free (page);
+// 페이지를 비웁니다.
+// ※ 해당 함수는 수정하지 마세요! ※
+void vm_dealloc_page(struct page *page) {
+  destroy(page);
+  free(page);
 }
 
 /* Claim the page that allocate on VA. */
-bool
-vm_claim_page (void *va UNUSED) {
-	struct page *page = NULL;
-	/* TODO: Fill this function */
+// VA로 할당된 페이지를 선언합니다.
+bool vm_claim_page(void *va UNUSED) {
+  struct page *page = NULL;
+  /* TODO: Fill this function */
+  // 기능을 구현하세요.
 
-	return vm_do_claim_page (page);
+  return vm_do_claim_page(page);
 }
 
 /* Claim the PAGE and set up the mmu. */
-static bool
-vm_do_claim_page (struct page *page) {
-	struct frame *frame = vm_get_frame ();
+// PAGE를 선언하고 mmu를 설정하세요.
+static bool vm_do_claim_page(struct page *page) {
+  struct frame *frame = vm_get_frame();
 
-	/* Set links */
-	frame->page = page;
-	page->frame = frame;
+  /* Set links */
+  frame->page = page;
+  page->frame = frame;
 
-	/* TODO: Insert page table entry to map page's VA to frame's PA. */
+  /* TODO: Insert page table entry to map page's VA to frame's PA. */
+  // 페이지의 VA를 프레임의 PA에 매핑하기 위해 페이지 테이블 항목을 삽입합니다.
 
-	return swap_in (page, frame->kva);
+  return swap_in(page, frame->kva);
 }
 
 /* Initialize new supplemental page table */
-void
-supplemental_page_table_init (struct supplemental_page_table *spt UNUSED) {
-}
+// 새로운 보충 페이지 테이블을 초기화합니다.
+void supplemental_page_table_init(struct supplemental_page_table *spt UNUSED) {}
 
 /* Copy supplemental page table from src to dst */
-bool
-supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
-		struct supplemental_page_table *src UNUSED) {
-}
+// src에서 dst로 보충 페이지 테이블 복사합니다.
+bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED,
+                                  struct supplemental_page_table *src UNUSED) {}
 
 /* Free the resource hold by the supplemental page table */
-void
-supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) {
-	/* TODO: Destroy all the supplemental_page_table hold by thread and
-	 * TODO: writeback all the modified contents to the storage. */
+// 보충 페이지 테이블에서 리소스 보류를 해제합니다.
+void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED) {
+  /* TODO: Destroy all the supplemental_page_table hold by thread and
+   * TODO: writeback all the modified contents to the storage. */
+  // 스레드가 보유한 supplemental_page_table을 모두 파괴하고 수정된 내용을 모두
+  // 저장소에 다시 쓰게 구현하세요.
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -146,7 +146,6 @@ static struct frame *vm_evict_frame(void) {
 // 사용자 풀 메모리가 가득 차면 이 함수는 프레임을 제거하여 사용 가능한 메모리
 // 공간을 가져옵니다.
 static struct frame *vm_get_frame(void) {
-  struct frame *frame = NULL;
   /* TODO: Fill this function. */
   void *kva = palloc_get_page(PAL_USER); // 물리 메모리 할당
 
@@ -205,10 +204,11 @@ void vm_dealloc_page(struct page *page) {
 /* Claim the page that allocate on VA. */
 // VA로 할당된 페이지를 선언합니다.
 bool vm_claim_page(void *va UNUSED) {
-  struct page *page = NULL;
   /* TODO: Fill this function */
   // 기능을 구현하세요.
-
+  struct page *page = spt_find_page(&thread_current()->spt, va);
+  if (page == NULL)
+    return false;
   return vm_do_claim_page(page);
 }
 


### PR DESCRIPTION
Frame Table부터 구현. PAL_USER 풀에서 실제 물리 페이지 할당 (palloc_get_page() 사용). 
페이지와 frame 연결. 해당 페이지에 프레임을 할당하고, pml4_set_page()로 가상 → 물리 매핑 수행.

SPT에 사용할 자료구조 정의 및 초기화 함수 구현- hash 구조 도입하여, page 구조체에 hash_elem을 추가. 페이지 검색 함수 구현 - 주어진 가상 주소 va에 대응되는 struct page 포인터를 supplemental_page_table에서 찾아 반환.해시 테이블의 탐색 기준인 키는 va가 속한 페이지의 시작 주소로 통일해야 하기 때문에 pg_round_down() 매크로를 사용->va를 페이지 경계로 정렬한 주소로 변환. 페이지 삽입 함수 구현 - 새로운 struct page를 SPT에 등록. 이미 같은 주소가 있으면 실패해야 함. hash_insert() 호출. 중복 키가 없을 경우만 성공 (NULL 반환 시 성공)
