### PR TITLE
[WEEK12] 김경연 - Anonymous Page

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -37,6 +37,13 @@ struct thread;
 
 #define VM_TYPE(type) ((type) & 7)
 
+struct lazy_load_arg {
+	struct file *file;
+	off_t ofs;
+	size_t read_bytes;
+	size_t zero_bytes;
+};
+
 /* The representation of "page".
  * This is kind of "parent class", which has four "child class"es, which are
  * uninit_page, file_page, anon_page, and page cache (project4).

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -2,6 +2,7 @@
 #define VM_VM_H
 #include <stdbool.h>
 #include "threads/palloc.h"
+#include "hash.h"
 
 enum vm_type {
 	/* page not initialized */
@@ -46,7 +47,9 @@ struct page {
 	struct frame *frame;   /* Back reference for frame */
 
 	/* Your implementation */
-
+	struct hash_elem elem;
+	bool rw_r;
+	bool rw_w;
 	/* Per-type data are binded into the union.
 	 * Each function automatically detects the current union */
 	union {
@@ -59,10 +62,13 @@ struct page {
 	};
 };
 
+
 /* The representation of "frame" */
 struct frame {
 	void *kva;
 	struct page *page;
+
+	struct list_elem elem;
 };
 
 /* The function table for page operations.
@@ -85,6 +91,7 @@ struct page_operations {
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
 struct supplemental_page_table {
+	struct hash spt_hash;
 };
 
 #include "threads/thread.h"

--- a/lib/kernel/hash.c
+++ b/lib/kernel/hash.c
@@ -275,7 +275,7 @@ uint64_t
 hash_int (int i) {
 	return hash_bytes (&i, sizeof i);
 }
-
+
 /* Returns the bucket in H that E belongs in. */
 static struct list *
 find_bucket (struct hash *h, struct hash_elem *e) {

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -140,14 +140,13 @@ page_fault(struct intr_frame* f) {
 	not_present = (f->error_code & PF_P) == 0;
 	write = (f->error_code & PF_W) != 0;
 	user = (f->error_code & PF_U) != 0;
-	exit(-1); // 추가
 
 #ifdef VM
 	/* For project 3 and later. */
 	if (vm_try_handle_fault(f, fault_addr, user, write, not_present))
 		return;
 #endif
-
+	exit(-1); // 추가	
 	/* Count page faults. */
 	page_fault_cnt++;
 

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -21,16 +21,23 @@ static const struct page_operations anon_ops = {
 void
 vm_anon_init (void) {
 	/* TODO: Set up the swap_disk. */
-	swap_disk = NULL;
-}
+
+	// 첫 번째 디스크 컨트롤러(0), 첫 번째 디스크(1) 설정
+	swap_disk = disk_get(1, 1);
+	ASSERT(swap_disk != NULL);  
+}	
 
 /* Initialize the file mapping */
 bool
 anon_initializer (struct page *page, enum vm_type type, void *kva) {
 	/* Set up the handler */
 	page->operations = &anon_ops;
+	page->frame->kva = kva;
 
+	// 필요 시 anon_page에 값 저장
 	struct anon_page *anon_page = &page->anon;
+
+	return true;
 }
 
 /* Swap in the page by read contents from the swap disk. */


### PR DESCRIPTION
```
[커널 부팅]
  └─ vm_anon_init()  ← (① 먼저 초기화)

[페이지 예약]
  └─ load_segment()  ← (④ 예약 시작)
        └─ vm_alloc_page_with_initializer() ← (③ UNINIT 생성)
              └─ anon_initializer() ← (② 핸들러 등록됨)

[실행 중 페이지 접근 → page fault 발생]
  └─ vm_try_handle_fault()
        └─ vm_do_claim_page()
              └─ swap_in()
                    └─ uninit_initialize() ← (⑥ 여기서 초기화 실행)
                          ├─ anon_initializer() ← 이미 구현됨
                          └─ lazy_load_segment() ← (⑤ 여기서 물리 메모리에 실제 로딩)
```

1. `vm_anon_init()` - 익명 페이지 서브 시스템 초기화. pintos 부팅 시 `vm_init()`에서 호출
2. `anon_initializer` - `uninit_initialize()`가 호출할 실제 anonymous page의 초기화 함수. `uninit_initialize()` → `anon_initializer()`
3. `vm_alloc_page_with_initializer()` - 페이지를 "lazy loading 예정"으로 예약하는 함수. `uninit_new()`로  `UNINIT` 페이지 생성 + `spt_insert_page()`로 초기화 핸들러 등록. `load_segment()`에서 호출
4. `load_segment()` - 파일 실행 시  페이지를 실제로 로딩하지 않고,  lazy load 예약 페이지만 생성. lazy_load_segment를 초기화 함수로 넘김. `process_exec()` → `load()`에서 호출
5. `lazy_load_segment()` - 페이지 폴트 발생 시 실제 파일에 aux로부터 정보 받아 실제 물리 메모리에 로딩 수행 데이터 로딩. `uninit_initialize()`를 통해 호출됨
