### PR TITLE
[WEEK12] 김경연 - Stack Growth

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -132,6 +132,9 @@ struct thread {
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */
 	struct supplemental_page_table spt;
+
+	void* stack_ptr;
+	void* stack_bottom;
 #endif
 
 	/* Owned by thread.c. */

--- a/include/userprog/syscall.h
+++ b/include/userprog/syscall.h
@@ -2,7 +2,11 @@
 #define USERPROG_SYSCALL_H
 
 void syscall_init(void);
+#ifndef VM
 void check_address(void* addr);
+#else
+struct page* check_address(void* addr);
+#endif
 
 struct lock filesys_lock;
 

--- a/include/vm/anon.h
+++ b/include/vm/anon.h
@@ -5,6 +5,9 @@ struct page;
 enum vm_type;
 
 struct anon_page {
+    int swap_slot;
+    // -1 -> not in swap_disk 
+    // else swap_disk slot index
 };
 
 void vm_anon_init (void);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -37,6 +37,13 @@ struct thread;
 
 #define VM_TYPE(type) ((type) & 7)
 
+struct vm_aux{
+	struct file* file;
+	off_t ofs;
+	size_t read_bytes;
+	size_t zero_bytes;
+};
+
 /* The representation of "page".
  * This is kind of "parent class", which has four "child class"es, which are
  * uninit_page, file_page, anon_page, and page cache (project4).

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -2,6 +2,7 @@
 #define VM_VM_H
 #include <stdbool.h>
 #include "threads/palloc.h"
+#include "hash.h"
 
 enum vm_type {
 	/* page not initialized */
@@ -46,7 +47,9 @@ struct page {
 	struct frame *frame;   /* Back reference for frame */
 
 	/* Your implementation */
-
+	struct hash_elem elem;
+	bool rw_r;
+	bool rw_w;
 	/* Per-type data are binded into the union.
 	 * Each function automatically detects the current union */
 	union {
@@ -59,10 +62,13 @@ struct page {
 	};
 };
 
+
 /* The representation of "frame" */
 struct frame {
 	void *kva;
 	struct page *page;
+
+	struct list_elem elem;
 };
 
 /* The function table for page operations.
@@ -85,6 +91,7 @@ struct page_operations {
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
 struct supplemental_page_table {
+	struct hash spt_hash;
 };
 
 #include "threads/thread.h"

--- a/lib/kernel/hash.c
+++ b/lib/kernel/hash.c
@@ -275,7 +275,7 @@ uint64_t
 hash_int (int i) {
 	return hash_bytes (&i, sizeof i);
 }
-
+
 /* Returns the bucket in H that E belongs in. */
 static struct list *
 find_bucket (struct hash *h, struct hash_elem *e) {

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -140,14 +140,17 @@ page_fault(struct intr_frame* f) {
 	not_present = (f->error_code & PF_P) == 0;
 	write = (f->error_code & PF_W) != 0;
 	user = (f->error_code & PF_U) != 0;
-	exit(-1); // 추가
 
 #ifdef VM
 	/* For project 3 and later. */
+	if ((!not_present && write) || (fault_addr < 0x400000 || fault_addr >= USER_STACK))
+	{
+		exit(-1);
+	}
 	if (vm_try_handle_fault(f, fault_addr, user, write, not_present))
 		return;
 #endif
-
+	exit(-1);
 	/* Count page faults. */
 	page_fault_cnt++;
 

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -762,6 +762,30 @@ lazy_load_segment(struct page* page, void* aux) {
 	/* TODO: Load the segment from the file */
 	/* TODO: This called when the first page fault occurs on address VA. */
 	/* TODO: VA is available when calling this function. */
+	struct vm_aux* load_arg = (struct vm_aux*) aux;
+	bool succ = true;
+	void *kva = page->frame->kva;
+	ASSERT(kva!=NULL);
+
+	if(load_arg->read_bytes > 0){
+		int bytes_read = file_read_at(
+            load_arg->file,
+            kva,
+            load_arg->read_bytes,
+            load_arg->ofs
+        );
+        if (bytes_read != (int) load_arg->read_bytes) {
+            succ = false;
+            goto done;
+        }
+	}
+
+    if (load_arg->zero_bytes > 0) {
+        memset(kva + load_arg->read_bytes, 0, load_arg->zero_bytes);
+    }
+done:
+    free(load_arg);
+    return succ;
 }
 
 /* Loads a segment starting at offset OFS in FILE at address
@@ -793,12 +817,22 @@ load_segment(struct file* file, off_t ofs, uint8_t* upage,
 		size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
 		/* TODO: Set up aux to pass information to the lazy_load_segment. */
-		void* aux = NULL;
-		if (!vm_alloc_page_with_initializer(VM_ANON, upage,
-			writable, lazy_load_segment, aux))
-			return false;
+
+		struct vm_aux* load_arg = malloc(sizeof(struct vm_aux));
+		if(load_arg == NULL) return false;
+		load_arg->file = file;
+		load_arg->ofs = ofs;
+		load_arg->read_bytes = page_read_bytes;
+		load_arg->zero_bytes = page_zero_bytes;
+
+		if (!vm_alloc_page_with_initializer(VM_FILE, upage,
+			writable, lazy_load_segment, load_arg)){
+				free(load_arg);
+				return false;
+		}
 
 		/* Advance. */
+		ofs += page_read_bytes;
 		read_bytes -= page_read_bytes;
 		zero_bytes -= page_zero_bytes;
 		upage += PGSIZE;
@@ -816,7 +850,16 @@ setup_stack(struct intr_frame* if_) {
 	 * TODO: If success, set the rsp accordingly.
 	 * TODO: You should mark the page is stack. */
 	 /* TODO: Your code goes here */
+	
+    if (vm_alloc_page(VM_ANON | VM_MARKER_0, stack_bottom, 1)) {
+        success = vm_claim_page(stack_bottom);
 
-	return success;
+        if (success) {
+            if_->rsp = USER_STACK;
+            thread_current()->stack_bottom = stack_bottom;
+        }
+    }
+    return success;
+
 }
 #endif /* VM */

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -122,12 +122,24 @@ syscall_handler(struct intr_frame* f UNUSED) {
 	}
 }
 
+#ifndef VM
 void check_address(void* addr) {
 	if (addr == NULL || !is_user_vaddr(addr) || pml4_get_page(thread_current()->pml4, addr) == NULL)
 	{
 		exit(-1);
 	}
 }
+#else
+struct page *check_address(void *addr) {
+    struct thread *curr = thread_current();
+
+    if (!is_user_vaddr(addr) || addr == NULL || !spt_find_page(&curr->spt, addr))
+        exit(-1);
+
+    return spt_find_page(&curr->spt, addr);
+}
+#endif
+
 
 /* ---------- system calls ---------- */
 void halt(void) {

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -71,6 +71,9 @@ syscall_handler(struct intr_frame* f UNUSED) {
 	/* %rdi, %rsi, %rdx, %r10, %r8, %r9 */
 	int syscall_number = (int)f->R.rax;
 
+#ifdef VM
+	thread_current()->stack_ptr = f->rsp;
+#endif
 	switch (syscall_number)
 	{
 	case SYS_HALT:
@@ -133,7 +136,7 @@ void check_address(void* addr) {
 struct page *check_address(void *addr) {
     struct thread *curr = thread_current();
 
-    if (!is_user_vaddr(addr) || addr == NULL || !spt_find_page(&curr->spt, addr))
+    if (!is_user_vaddr(addr) || addr == NULL)
         exit(-1);
 
     return spt_find_page(&curr->spt, addr);

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -3,6 +3,7 @@
 #include "vm/vm.h"
 #include "devices/disk.h"
 #include "lib/kernel/bitmap.h"
+#include "threads/mmu.h"
 
 /* DO NOT MODIFY BELOW LINE */
 static struct disk *swap_disk;
@@ -56,18 +57,29 @@ anon_initializer (struct page *page, enum vm_type type, void *kva) {
 
 	struct anon_page *anon_page = &page->anon;
 	anon_page->swap_slot = -1;
+
+	return true;
 }
 
 /* Swap in the page by read contents from the swap disk. */
 static bool
 anon_swap_in (struct page *page, void *kva) {
 	struct anon_page *anon_page = &page->anon;
+	ASSERT(page != NULL);
+	ASSERT(kva != NULL);
+
+	// Stack Growth의 경우 swap 영역이 없으므로 0으로 초기화
+	memset(kva, 0, PGSIZE);
+	return true;
 }
 
 /* Swap out the page by writing contents to the swap disk. */
 static bool
 anon_swap_out (struct page *page) {
 	struct anon_page *anon_page = &page->anon;
+	ASSERT(page != NULL);
+
+	return true;
 }
 
 /* Destroy the anonymous page. PAGE will be freed by the caller. */

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -2,6 +2,7 @@
 
 #include "vm/vm.h"
 #include "devices/disk.h"
+#include "lib/kernel/bitmap.h"
 
 /* DO NOT MODIFY BELOW LINE */
 static struct disk *swap_disk;
@@ -17,20 +18,44 @@ static const struct page_operations anon_ops = {
 	.type = VM_ANON,
 };
 
+static struct bitmap* swap_table;
+static struct lock swap_lock;
+
 /* Initialize the data for anonymous pages */
 void
 vm_anon_init (void) {
 	/* TODO: Set up the swap_disk. */
-	swap_disk = NULL;
+	swap_disk = disk_get(1, 1);
+	if(swap_disk == NULL) PANIC("vm_anon_init: swap_disk failed");
+
+	size_t total_sectors = disk_size(swap_disk);
+	if(!total_sectors) PANIC("vm_anon_init: zero_sectors");
+
+	
+	size_t sector_count = (1<<12) / DISK_SECTOR_SIZE;
+	ASSERT(sector_count > 0);
+
+	size_t total_slots = total_sectors / sector_count;
+	if(!total_slots) PANIC("vm_anon_init: disk too small");
+
+	swap_table = bitmap_create(total_slots);
+	if(swap_table == NULL) PANIC("vm_anon_init: bitmap failed");
+
+	bitmap_set_all(swap_table, false);
+
+	lock_init(&swap_lock);
 }
 
 /* Initialize the file mapping */
 bool
 anon_initializer (struct page *page, enum vm_type type, void *kva) {
 	/* Set up the handler */
+	ASSERT(type == VM_ANON);
+
 	page->operations = &anon_ops;
 
 	struct anon_page *anon_page = &page->anon;
+	anon_page->swap_slot = -1;
 }
 
 /* Swap in the page by read contents from the swap disk. */

--- a/vm/uninit.c
+++ b/vm/uninit.c
@@ -52,7 +52,7 @@ uninit_initialize (struct page *page, void *kva) {
 	void *aux = uninit->aux;
 
 	/* TODO: You may need to fix this function. */
-	return uninit->page_initializer (page, uninit->type, kva) &&
+	return uninit->page_initializer (page, uninit->type, aux) &&
 		(init ? init (page, aux) : true);
 }
 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -81,7 +81,7 @@ bool
 vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		vm_initializer *init, void *aux) {
 
-	ASSERT (VM_TYPE(type) != VM_UNINIT)
+	ASSERT (VM_TYPE(type) != VM_UNINIT);
 
 	struct supplemental_page_table *spt = &thread_current ()->spt;
 
@@ -115,13 +115,11 @@ struct page *
 spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 	struct page *page = NULL;
 	/* TODO: Fill this function. */
-	page = (struct page*)malloc(sizeof(struct page));
-	page->va = pg_round_down(va);
-
-	struct hash_elem* find_e = hash_find(&spt->spt_hash, &(page->elem));
-	free(page);
-
-	if(find_e == NULL) return NULL;
+	struct page temp;
+	temp.va = pg_round_down(va);
+	
+	struct hash_elem* find_e = hash_find(&spt->spt_hash, &temp.elem);
+	if (find_e == NULL) return NULL;
 
 	return hash_entry(find_e, struct page, elem);
 }
@@ -269,8 +267,8 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 		// 스택 접근인지 다른 접근인지 휴리스틱 판단
 		uint64_t rsp = f->rsp;
 		
-		//조건 1: addr >= rsp - 8
-		if((uint64_t)addr < rsp - 8) {
+		//조건 1: addr >= rsp - 32
+		if((uint64_t)addr < rsp - 32) {
 			return false;
 		}
 


### PR DESCRIPTION
1. 유저 스택이 기존 1페이지(4KB)를 넘으면, 페이지 폴트가 발생하고
2. 해당 접근이 스택 증가로 유효한 경우라면 
-> 새 페이지를 할당해야 함

- 총 스택 크기가 최대 1MB를 넘으면 안 됨

-------------------------------------------------------------
1단계: `vm_try_handle_fault()` 수정
- 스택 접근 판별 휴리스틱 적용 - 스택 포인터보다 8바이트 이상 낮거나 너무 멀면 무시
- 스택 최대 크기 초과 확인 (1MB 초과 시 허용 안함)
- 성립 시 `vm_stack_growth(addr)` 호출

2단계: `vm_stack_growth()` 구현
- fault address 기준으로 페이지 단위로 아래 방향 스택 페이지들을 할당
- addr을 `PGSIZE` 단위로 내림한 주소부터 시작
- Anonymous 페이지로 `vm_alloc_page_with_initializer()`를 호출
